### PR TITLE
Update connections documentation

### DIFF
--- a/en/api_reference/classdronecore_1_1_drone_core.md
+++ b/en/api_reference/classdronecore_1_1_drone_core.md
@@ -27,10 +27,12 @@ Type | Name | Description
 ---: | --- | ---
 &nbsp; | [DroneCore](#classdronecore_1_1_drone_core_1a0b94dd09cd46faa41742d3720f210aa2) () | Constructor.
 &nbsp; | [~DroneCore](#classdronecore_1_1_drone_core_1abbaedb6fd922c023e53611b484b38582) () | Destructor.
-[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_any_connection](#classdronecore_1_1_drone_core_1a384ae5189b047dd3df8d7e90c42fa021) (const std::string & connection_url=DEFAULT_UDP_CONNECTION_URL) | Adds Connection via URL.
-[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_udp_connection](#classdronecore_1_1_drone_core_1a7a04fbacf95eb6b21418032c8287dfbb) (int local_port_number=DEFAULT_UDP_PORT) | Adds a UDP connection to the specified port number.
-[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_tcp_connection](#classdronecore_1_1_drone_core_1a725640cb53c0d077e753ea2d22717b68) (const std::string & remote_ip=DEFAULT_TCP_REMOTE_IP, int remote_port=DEFAULT_TCP_REMOTE_PORT) | Adds a TCP connection with a specific IP address and port number.
-[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_serial_connection](#classdronecore_1_1_drone_core_1abde7ed4d42875dc85c73d34fedab2902) (const std::string & dev_path=DEFAULT_SERIAL_DEV_PATH, int baudrate=DEFAULT_SERIAL_BAUDRATE) | Adds a serial connection with a specific port (COM or UART dev node) and baudrate as specified.
+[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_any_connection](#classdronecore_1_1_drone_core_1a4d456788b98920c58b07e6a280642168) (const std::string & connection_url) | Adds Connection via URL.
+[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_udp_connection](#classdronecore_1_1_drone_core_1a38e5715ec8817515ccaba5034da30bcd) (int local_port=[DEFAULT_UDP_PORT](classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1aa989b494349529f412b36984a46f2ca6)) | Adds a UDP connection to the specified port number.
+[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_udp_connection](#classdronecore_1_1_drone_core_1a2137a809643ef22d8b14617bf9897fac) (const std::string & local_ip, int local_port=[DEFAULT_UDP_PORT](classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1aa989b494349529f412b36984a46f2ca6)) | Adds a UDP connection to the specified port number and local interface.
+[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_tcp_connection](#classdronecore_1_1_drone_core_1abaa49c13d6277177974a09ccffde82e1) (int remote_port=[DEFAULT_TCP_REMOTE_PORT](classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a0ded56f7f5873f17e424343ed7b2e5af)) | Adds a TCP connection with a specific port number on localhost.
+[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_tcp_connection](#classdronecore_1_1_drone_core_1aae9952302358ca587f300ca004a83776) (const std::string & remote_ip, int remote_port=[DEFAULT_TCP_REMOTE_PORT](classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a0ded56f7f5873f17e424343ed7b2e5af)) | Adds a TCP connection with a specific IP address and port number.
+[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) | [add_serial_connection](#classdronecore_1_1_drone_core_1aa84b8bfba099631267a0319169c23c8e) (const std::string & dev_path, int baudrate=DEFAULT_SERIAL_BAUDRATE) | Adds a serial connection with a specific port (COM or UART dev node) and baudrate as specified.
 std::vector< uint64_t > | [system_uuids](#classdronecore_1_1_drone_core_1ac9503e701727ffa0293a30a6c8326f10) () const | Get vector of system UUIDs.
 [System](classdronecore_1_1_system.md) & | [system](#classdronecore_1_1_drone_core_1ac9b0cdfc518ff036d7edf450153fe941) () const | Get the first discovered system.
 [System](classdronecore_1_1_system.md) & | [system](#classdronecore_1_1_drone_core_1ab6082fca008ae58b79e87676336506ac) (uint64_t uuid)const | Get the system with the specified UUID.
@@ -42,19 +44,16 @@ void | [register_on_timeout](#classdronecore_1_1_drone_core_1ad8c0dc0100449d21a4
 ## Static Public Attributes
 
 
-static constexpr auto [DEFAULT_UDP_CONNECTION_URL](#classdronecore_1_1_drone_core_1aef2ad569dd9a7d0762b1d17d21e7f598) = "udp://:14540" - 
+static constexpr auto [DEFAULT_UDP_BIND_IP](#classdronecore_1_1_drone_core_1a58ace8e05507a0ca301718bcd09785cf) = "0.0.0.0" - Default UDP bind IP (accepts any incoming connections).
 
 
-static constexpr int [DEFAULT_UDP_PORT](#classdronecore_1_1_drone_core_1aa989b494349529f412b36984a46f2ca6) = 14540 - 
+static constexpr int [DEFAULT_UDP_PORT](#classdronecore_1_1_drone_core_1aa989b494349529f412b36984a46f2ca6) = 14540 - Default UDP bind port (same port as used by MAVROS).
 
 
-static constexpr auto [DEFAULT_TCP_REMOTE_IP](#classdronecore_1_1_drone_core_1ade2086911d3052093fb87717f58a99b2) = "127.0.0.1" - 
+static constexpr auto [DEFAULT_TCP_REMOTE_IP](#classdronecore_1_1_drone_core_1ade2086911d3052093fb87717f58a99b2) = "127.0.0.1" - Default TCP remote IP (localhost).
 
 
-static constexpr int [DEFAULT_TCP_REMOTE_PORT](#classdronecore_1_1_drone_core_1a0ded56f7f5873f17e424343ed7b2e5af) = 5760 - 
-
-
-static constexpr auto [DEFAULT_SERIAL_DEV_PATH](#classdronecore_1_1_drone_core_1a67928c93b8b8f2ab65cf28a4b6d9436f) = "/dev/ttyS0" - 
+static constexpr int [DEFAULT_TCP_REMOTE_PORT](#classdronecore_1_1_drone_core_1a0ded56f7f5873f17e424343ed7b2e5af) = 5760 - Default serial baudrate.
 
 
 static constexpr int [DEFAULT_SERIAL_BAUDRATE](#classdronecore_1_1_drone_core_1a2b20d34acc312ffe6197aebdc6769a86) = 57600 - 
@@ -102,9 +101,9 @@ Callback type for discover and timeout notifications.
 ## Member Function Documentation
 
 
-### add_any_connection() {#classdronecore_1_1_drone_core_1a384ae5189b047dd3df8d7e90c42fa021}
+### add_any_connection() {#classdronecore_1_1_drone_core_1a4d456788b98920c58b07e6a280642168}
 ```cpp
-ConnectionResult dronecore::DroneCore::add_any_connection(const std::string &connection_url=DEFAULT_UDP_CONNECTION_URL)
+ConnectionResult dronecore::DroneCore::add_any_connection(const std::string &connection_url)
 ```
 
 
@@ -113,18 +112,9 @@ Adds Connection via URL.
 Supports connection: Serial, TCP or UDP. Connection URL format should be:
 <ul>
 <li><p>UDP - udp://[Bind_host][:Bind_port]</p></li>
-<li><p>TCP - tcp://[Server_host][:Server_port]</p></li>
-<li><p>Serial - serial://[Dev_Node][:Baudrate]</p></li>
+<li><p>TCP - tcp://[Remote_host][:Remote_port]</p></li>
+<li><p>Serial - serial://Dev_Node[:Baudrate]</p></li>
 </ul>
-
-
-Default URL : udp://:14540.
-<ul>
-<li><p>Default Bind host IP is localhost(127.0.0.1)</p></li>
-</ul>
-
-
-> **Warning** Serial connections are not supported on Windows (they are supported on Linux and macOS).
 
 **Parameters**
 
@@ -134,26 +124,63 @@ Default URL : udp://:14540.
 
 &emsp;[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) - The result of adding the connection.
 
-### add_udp_connection() {#classdronecore_1_1_drone_core_1a7a04fbacf95eb6b21418032c8287dfbb}
+### add_udp_connection() {#classdronecore_1_1_drone_core_1a38e5715ec8817515ccaba5034da30bcd}
 ```cpp
-ConnectionResult dronecore::DroneCore::add_udp_connection(int local_port_number=DEFAULT_UDP_PORT)
+ConnectionResult dronecore::DroneCore::add_udp_connection(int local_port=DEFAULT_UDP_PORT)
 ```
 
 
 Adds a UDP connection to the specified port number.
 
+Any incoming connections are accepted (0.0.0.0).
 
 **Parameters**
 
-* int **local_port_number** - The local UDP port to listen to (defaults to 14540, the same as mavros).
+* int **local_port** - The local UDP port to listen to (defaults to 14540, the same as MAVROS).
 
 **Returns**
 
 &emsp;[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) - The result of adding the connection.
 
-### add_tcp_connection() {#classdronecore_1_1_drone_core_1a725640cb53c0d077e753ea2d22717b68}
+### add_udp_connection() {#classdronecore_1_1_drone_core_1a2137a809643ef22d8b14617bf9897fac}
 ```cpp
-ConnectionResult dronecore::DroneCore::add_tcp_connection(const std::string &remote_ip=DEFAULT_TCP_REMOTE_IP, int remote_port=DEFAULT_TCP_REMOTE_PORT)
+ConnectionResult dronecore::DroneCore::add_udp_connection(const std::string &local_ip, int local_port=DEFAULT_UDP_PORT)
+```
+
+
+Adds a UDP connection to the specified port number and local interface.
+
+To accept only local connections of the machine, use 127.0.0.1. For any incoming connections, use 0.0.0.0.
+
+**Parameters**
+
+* const std::string& **local_ip** - 
+* int **local_port** - The local UDP port to listen to (defaults to 14540, the same as MAVROS).
+
+**Returns**
+
+&emsp;[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) - The result of adding the connection.
+
+### add_tcp_connection() {#classdronecore_1_1_drone_core_1abaa49c13d6277177974a09ccffde82e1}
+```cpp
+ConnectionResult dronecore::DroneCore::add_tcp_connection(int remote_port=DEFAULT_TCP_REMOTE_PORT)
+```
+
+
+Adds a TCP connection with a specific port number on localhost.
+
+
+**Parameters**
+
+* int **remote_port** - The TCP port to connect to (defaults to 5760).
+
+**Returns**
+
+&emsp;[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) - The result of adding the connection.
+
+### add_tcp_connection() {#classdronecore_1_1_drone_core_1aae9952302358ca587f300ca004a83776}
+```cpp
+ConnectionResult dronecore::DroneCore::add_tcp_connection(const std::string &remote_ip, int remote_port=DEFAULT_TCP_REMOTE_PORT)
 ```
 
 
@@ -162,26 +189,25 @@ Adds a TCP connection with a specific IP address and port number.
 
 **Parameters**
 
-* const std::string& **remote_ip** - Remote IP address to connect to (defaults to 127.0.0.1).
+* const std::string& **remote_ip** - Remote IP address to connect to.
 * int **remote_port** - The TCP port to connect to (defaults to 5760).
 
 **Returns**
 
 &emsp;[ConnectionResult](namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) - The result of adding the connection.
 
-### add_serial_connection() {#classdronecore_1_1_drone_core_1abde7ed4d42875dc85c73d34fedab2902}
+### add_serial_connection() {#classdronecore_1_1_drone_core_1aa84b8bfba099631267a0319169c23c8e}
 ```cpp
-ConnectionResult dronecore::DroneCore::add_serial_connection(const std::string &dev_path=DEFAULT_SERIAL_DEV_PATH, int baudrate=DEFAULT_SERIAL_BAUDRATE)
+ConnectionResult dronecore::DroneCore::add_serial_connection(const std::string &dev_path, int baudrate=DEFAULT_SERIAL_BAUDRATE)
 ```
 
 
 Adds a serial connection with a specific port (COM or UART dev node) and baudrate as specified.
 
-> **Warning** This method is not supported on Windows (it is supported on Linux and macOS).
 
 **Parameters**
 
-* const std::string& **dev_path** - COM or UART dev node name/path (defaults to "/dev/ttyS0").
+* const std::string& **dev_path** - COM or UART dev node name/path (e.g. "/dev/ttyS0", or "COM3" on Windows).
 * int **baudrate** - Baudrate of the serial port (defaults to 57600).
 
 **Returns**
@@ -309,11 +335,14 @@ This sets a callback that will be notified if no heartbeat of the system has bee
 ## Field Documentation
 
 
-### DEFAULT_UDP_CONNECTION_URL {#classdronecore_1_1_drone_core_1aef2ad569dd9a7d0762b1d17d21e7f598}
+### DEFAULT_UDP_BIND_IP {#classdronecore_1_1_drone_core_1a58ace8e05507a0ca301718bcd09785cf}
 
 ```cpp
-constexpr auto dronecore::DroneCore::DEFAULT_UDP_CONNECTION_URL = "udp://:14540"
+constexpr auto dronecore::DroneCore::DEFAULT_UDP_BIND_IP = "0.0.0.0"
 ```
+
+
+Default UDP bind IP (accepts any incoming connections).
 
 
 ### DEFAULT_UDP_PORT {#classdronecore_1_1_drone_core_1aa989b494349529f412b36984a46f2ca6}
@@ -323,12 +352,19 @@ constexpr int dronecore::DroneCore::DEFAULT_UDP_PORT = 14540
 ```
 
 
+Default UDP bind port (same port as used by MAVROS).
+
+
 ### DEFAULT_TCP_REMOTE_IP {#classdronecore_1_1_drone_core_1ade2086911d3052093fb87717f58a99b2}
 
 ```cpp
 constexpr auto dronecore::DroneCore::DEFAULT_TCP_REMOTE_IP = "127.0.0.1"
 ```
 
+
+Default TCP remote IP (localhost).
+
+Default TCP remote port.
 
 ### DEFAULT_TCP_REMOTE_PORT {#classdronecore_1_1_drone_core_1a0ded56f7f5873f17e424343ed7b2e5af}
 
@@ -337,11 +373,7 @@ constexpr int dronecore::DroneCore::DEFAULT_TCP_REMOTE_PORT = 5760
 ```
 
 
-### DEFAULT_SERIAL_DEV_PATH {#classdronecore_1_1_drone_core_1a67928c93b8b8f2ab65cf28a4b6d9436f}
-
-```cpp
-constexpr auto dronecore::DroneCore::DEFAULT_SERIAL_DEV_PATH = "/dev/ttyS0"
-```
+Default serial baudrate.
 
 
 ### DEFAULT_SERIAL_BAUDRATE {#classdronecore_1_1_drone_core_1a2b20d34acc312ffe6197aebdc6769a86}

--- a/en/api_reference/namespacedronecore.md
+++ b/en/api_reference/namespacedronecore.md
@@ -45,6 +45,14 @@ bool | [operator==](#namespacedronecore_1a65e8014734a31eaf756b98b672dd6466) (con
 std::ostream & | [operator<<](#namespacedronecore_1a80860746c1bda3cc94fb5ab3962cd6f6) (std::ostream & str, [Telemetry::GPSInfo](structdronecore_1_1_telemetry_1_1_g_p_s_info.md) const & gps_info) |
 bool | [operator==](#namespacedronecore_1ae113d4a3da31a7baa40029e3a1833e86) (const [Telemetry::Battery](structdronecore_1_1_telemetry_1_1_battery.md) & lhs, const [Telemetry::Battery](structdronecore_1_1_telemetry_1_1_battery.md) & rhs) |
 std::ostream & | [operator<<](#namespacedronecore_1a5e9f9c205d03cca66694584afb649155) (std::ostream & str, [Telemetry::Battery](structdronecore_1_1_telemetry_1_1_battery.md) const & battery) |
+bool | [operator==](#namespacedronecore_1a76393963fd7c444510369aa84f75a510) (const [Telemetry::Quaternion](structdronecore_1_1_telemetry_1_1_quaternion.md) & lhs, const [Telemetry::Quaternion](structdronecore_1_1_telemetry_1_1_quaternion.md) & rhs) |
+std::ostream & | [operator<<](#namespacedronecore_1a64ba6a17f16435543665842c77978b7f) (std::ostream & str, [Telemetry::Quaternion](structdronecore_1_1_telemetry_1_1_quaternion.md) const & quaternion) |
+bool | [operator==](#namespacedronecore_1ab79eb5727113df246d7a9831bd6d411e) (const [Telemetry::EulerAngle](structdronecore_1_1_telemetry_1_1_euler_angle.md) & lhs, const [Telemetry::EulerAngle](structdronecore_1_1_telemetry_1_1_euler_angle.md) & rhs) |
+std::ostream & | [operator<<](#namespacedronecore_1a74ec1af5c36cf3c5709655b28079c041) (std::ostream & str, [Telemetry::EulerAngle](structdronecore_1_1_telemetry_1_1_euler_angle.md) const & euler_angle) |
+bool | [operator==](#namespacedronecore_1aedab25310e4642ea7bc35c2dd04040a3) (const [Telemetry::GroundSpeedNED](structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md) & lhs, const [Telemetry::GroundSpeedNED](structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md) & rhs) |
+std::ostream & | [operator<<](#namespacedronecore_1a30d9e948976cd9da8692f0e68fab9241) (std::ostream & str, [Telemetry::GroundSpeedNED](structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md) const & ground_speed) |
+bool | [operator==](#namespacedronecore_1a6b84d191db124cabb9115a37fb01958a) (const [Telemetry::RCStatus](structdronecore_1_1_telemetry_1_1_r_c_status.md) & lhs, const [Telemetry::RCStatus](structdronecore_1_1_telemetry_1_1_r_c_status.md) & rhs) |
+std::ostream & | [operator<<](#namespacedronecore_1abd2ed9cab741fc0c46d270a6df643d94) (std::ostream & str, [Telemetry::RCStatus](structdronecore_1_1_telemetry_1_1_r_c_status.md) const & rc_status) |
 
 ## Enumeration Type Documentation
 
@@ -350,6 +358,158 @@ std::ostream& dronecore::operator<<(std::ostream &str, Telemetry::Battery const 
 
 * std::ostream& **str** - 
 * [Telemetry::Battery](structdronecore_1_1_telemetry_1_1_battery.md) const& **battery** - 
+
+**Returns**
+
+&emsp;std::ostream & - 
+
+### operator==() {#namespacedronecore_1a76393963fd7c444510369aa84f75a510}
+
+```
+#include: telemetry.h
+```
+```cpp
+bool dronecore::operator==(const Telemetry::Quaternion &lhs, const Telemetry::Quaternion &rhs)
+```
+
+
+**Parameters**
+
+* const [Telemetry::Quaternion](structdronecore_1_1_telemetry_1_1_quaternion.md)& **lhs** - 
+* const [Telemetry::Quaternion](structdronecore_1_1_telemetry_1_1_quaternion.md)& **rhs** - 
+
+**Returns**
+
+&emsp;bool - 
+
+### operator<<() {#namespacedronecore_1a64ba6a17f16435543665842c77978b7f}
+
+```
+#include: telemetry.h
+```
+```cpp
+std::ostream& dronecore::operator<<(std::ostream &str, Telemetry::Quaternion const &quaternion)
+```
+
+
+**Parameters**
+
+* std::ostream& **str** - 
+* [Telemetry::Quaternion](structdronecore_1_1_telemetry_1_1_quaternion.md) const& **quaternion** - 
+
+**Returns**
+
+&emsp;std::ostream & - 
+
+### operator==() {#namespacedronecore_1ab79eb5727113df246d7a9831bd6d411e}
+
+```
+#include: telemetry.h
+```
+```cpp
+bool dronecore::operator==(const Telemetry::EulerAngle &lhs, const Telemetry::EulerAngle &rhs)
+```
+
+
+**Parameters**
+
+* const [Telemetry::EulerAngle](structdronecore_1_1_telemetry_1_1_euler_angle.md)& **lhs** - 
+* const [Telemetry::EulerAngle](structdronecore_1_1_telemetry_1_1_euler_angle.md)& **rhs** - 
+
+**Returns**
+
+&emsp;bool - 
+
+### operator<<() {#namespacedronecore_1a74ec1af5c36cf3c5709655b28079c041}
+
+```
+#include: telemetry.h
+```
+```cpp
+std::ostream& dronecore::operator<<(std::ostream &str, Telemetry::EulerAngle const &euler_angle)
+```
+
+
+**Parameters**
+
+* std::ostream& **str** - 
+* [Telemetry::EulerAngle](structdronecore_1_1_telemetry_1_1_euler_angle.md) const& **euler_angle** - 
+
+**Returns**
+
+&emsp;std::ostream & - 
+
+### operator==() {#namespacedronecore_1aedab25310e4642ea7bc35c2dd04040a3}
+
+```
+#include: telemetry.h
+```
+```cpp
+bool dronecore::operator==(const Telemetry::GroundSpeedNED &lhs, const Telemetry::GroundSpeedNED &rhs)
+```
+
+
+**Parameters**
+
+* const [Telemetry::GroundSpeedNED](structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md)& **lhs** - 
+* const [Telemetry::GroundSpeedNED](structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md)& **rhs** - 
+
+**Returns**
+
+&emsp;bool - 
+
+### operator<<() {#namespacedronecore_1a30d9e948976cd9da8692f0e68fab9241}
+
+```
+#include: telemetry.h
+```
+```cpp
+std::ostream& dronecore::operator<<(std::ostream &str, Telemetry::GroundSpeedNED const &ground_speed)
+```
+
+
+**Parameters**
+
+* std::ostream& **str** - 
+* [Telemetry::GroundSpeedNED](structdronecore_1_1_telemetry_1_1_ground_speed_n_e_d.md) const& **ground_speed** - 
+
+**Returns**
+
+&emsp;std::ostream & - 
+
+### operator==() {#namespacedronecore_1a6b84d191db124cabb9115a37fb01958a}
+
+```
+#include: telemetry.h
+```
+```cpp
+bool dronecore::operator==(const Telemetry::RCStatus &lhs, const Telemetry::RCStatus &rhs)
+```
+
+
+**Parameters**
+
+* const [Telemetry::RCStatus](structdronecore_1_1_telemetry_1_1_r_c_status.md)& **lhs** - 
+* const [Telemetry::RCStatus](structdronecore_1_1_telemetry_1_1_r_c_status.md)& **rhs** - 
+
+**Returns**
+
+&emsp;bool - 
+
+### operator<<() {#namespacedronecore_1abd2ed9cab741fc0c46d270a6df643d94}
+
+```
+#include: telemetry.h
+```
+```cpp
+std::ostream& dronecore::operator<<(std::ostream &str, Telemetry::RCStatus const &rc_status)
+```
+
+
+**Parameters**
+
+* std::ostream& **str** - 
+* [Telemetry::RCStatus](structdronecore_1_1_telemetry_1_1_r_c_status.md) const& **rc_status** - 
 
 **Returns**
 

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -31,9 +31,10 @@ PX4 supports a [number of simulators](https://dev.px4.io/en/simulation/). In ord
 
 > **Note** JMAVSim can only be used to simulate multicopters. Gazebo additionally supports a number of [other vehicles](https://dev.px4.io/en/simulation/gazebo.html#html#running-the-simulation) (e.g. VTOL, Rovers, fixed-wing etc.).
 
-After running a standard installation, a multicopter simulation can be started from the PX4 **/Firmware** directory using the command:
-* jMAVSim: `make posix_sitl_default jmavsim`
-* Gazebo: `make posix_sitl_default gazebo`
+After running a standard installation, a simulation can be started from the PX4 **/Firmware** directory using the command:
+* Multicopter (jMAVSim): `make posix_sitl_default jmavsim`
+* Multicopter (Gazebo): `make posix_sitl_default gazebo`
+* VTOL (Gazebo):  `make posix_sitl_default gazebo_standard_vtol`
 
 
 ### Using QGroundControl
@@ -87,7 +88,7 @@ cmake --build .
 
 ### Running the Examples {#running_the_examples}
 
-You can then run the new executable, specifying the connection URL as the first argument.
+You can then run the example, specifying the connection URL as the first argument.
 When running with the Simulator, you will use the connection string: `udp://:14540`
  
 On Linux/macOS you would run the following (from the **\build** directory): 

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -19,11 +19,10 @@ The examples are "largely" built and run in the same way, as described in the fo
 
 ## Trying the Examples {#trying_the_examples}
 
-The examples are designed to automatically connect to a [simulated PX4 vehicle](https://dev.px4.io/en/simulation/) that is running on the same computer.
+The easiest way to test the examples is to use a [simulated PX4 vehicle](https://dev.px4.io/en/simulation/) that is running on the same computer.
+First start PX4 in SITL (Simulation), optionally start *QGroundControl* to observe the vehicle, then build and run the example code. 
 
-In order to test them, first start PX4 in SITL (Simulation), optionally start *QGroundControl* to observe the vehicle, then build and run the example code. 
-
-> **Note** The simulator broadcasts to the standard PX4 UDP port for connecting to offboard APIs (14540). The examples connect to this port by default, using [DroneCore::add_udp_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a7a04fbacf95eb6b21418032c8287dfbb).
+> **Note** The simulator broadcasts to the standard PX4 UDP port for connecting to offboard APIs (14540). The examples connect to this port using either [add_any_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a4d456788b98920c58b07e6a280642168) or [add_udp_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a38e5715ec8817515ccaba5034da30bcd).
 
 
 ### Setting up a Simulator
@@ -82,21 +81,23 @@ cd example/takeoff_and_land/
 mkdir build && cd build
 cmake .. -G "Visual Studio 15 2017 Win64"
 cmake --build .
-.\Debug\takeoff_and_land.exe
 ```
 
 > **Note** The debug binary for the example is stored under **\Debug** folder.
 
 ### Running the Examples {#running_the_examples}
 
-On Linux/macOS you can then run the new executable (from the **\build** directory):
+You can then run the new executable, specifying the connection URL as the first argument.
+When running with the Simulator, you will use the connection string: `udp://:14540`
+ 
+On Linux/macOS you would run the following (from the **\build** directory): 
 ```sh
-./takeoff_and_land
+./takeoff_and_land udp://:14540
 ```
 
-For Windows you launch the file from the **\build\Debug\** directory:
-```sh
-.\Debug\takeoff_and_land.exe
+For Windows you would run the following (from the **\build\Debug\** directory):
+```cmd
+.\Debug\takeoff_and_land.exe udp://:14540
 ```
 
 

--- a/en/examples/fly_mission.md
+++ b/en/examples/fly_mission.md
@@ -14,56 +14,42 @@ The example terminal output should be similar to that shown below:
 > **Note** This is from a debug build of DroneCore. A release build will omit the "Debug" messages.
 
 ```
-$ ./fly_mission 
+$ ./fly_mission udp://:14540
+```
+```
 Waiting to discover system...
-[03:42:51|Info ] New system on: 127.0.0.1:14557 (udp_connection.cpp:210)
-[03:42:51|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2017-11-14/2 (device_impl.cpp:225)
-[03:42:51|Debug] Discovered 4294967298 (dronecore_impl.cpp:234)
+[01:04:37|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:208)
+[01:04:37|Debug] New: System ID: 1 Comp ID: 1 (dronecore_impl.cpp:286)
+[01:04:37|Debug] Component Autopilot added. (mavlink_system.cpp:349)
+[01:04:37|Debug] Found 1 component(s). (mavlink_system.cpp:481)
+[01:04:37|Debug] Discovered 4294967298 (mavlink_system.cpp:483)
 Discovered system with UUID: 4294967298
-Waiting for system to be ready
-...
 Waiting for system to be ready
 System ready
 Creating and uploading mission
 Uploading mission...
-[03:43:07|Debug] Send mission item 0 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 1 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 2 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 3 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 4 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 5 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 6 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 7 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 8 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 9 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 10 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 11 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 12 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 13 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 14 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 15 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 16 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 17 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 18 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 19 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 20 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 21 (mission_impl.cpp:712)
-[03:43:07|Debug] Send mission item 22 (mission_impl.cpp:712)
-[03:43:07|Info ] Mission accepted (mission_impl.cpp:136)
+[01:04:38|Debug] Send mission item 0 (mission_impl.cpp:904)
+[01:04:38|Debug] Send mission item 1 (mission_impl.cpp:904)
+[01:04:38|Debug] Send mission item 2 (mission_impl.cpp:904)
+...
+[01:04:38|Debug] Send mission item 21 (mission_impl.cpp:904)
+[01:04:38|Debug] Send mission item 22 (mission_impl.cpp:904)
+[01:04:38|Info ] Mission accepted (mission_impl.cpp:162)
 Mission uploaded.
 Arming...
-[03:43:07|Debug] MAVLink: info: ARMED by arm/disarm component command (device_impl.cpp:225)
 Armed.
 Starting mission.
+[01:04:38|Debug] MAVLink: info: ARMED by arm/disarm component command (mavlink_system.cpp:286)
 Started mission.
-[03:43:07|Debug] MAVLink: info: Executing mission. (device_impl.cpp:225)
-[03:43:07|Debug] MAVLink: info: Takeoff to 10.0 meters above home. (device_impl.cpp:225)
-[03:43:07|Debug] MAVLink: info: Takeoff detected (device_impl.cpp:225)
+[01:04:38|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2018-05-23/0 (mavlink_system.cpp:286)
+[01:04:38|Debug] MAVLink: info: Executing mission. (mavlink_system.cpp:286)
+[01:04:38|Debug] MAVLink: info: Takeoff to 10.0 meters above home. (mavlink_system.cpp:286)
+[01:04:38|Debug] MAVLink: info: Takeoff detected (mavlink_system.cpp:286)
 Mission status update: 0 / 6
+...
 Mission status update: 0 / 6
 Mission status update: 1 / 6
-Mission status update: 1 / 6
-Mission status update: 1 / 6
+...
 Mission status update: 1 / 6
 Mission status update: 2 / 6
 Pausing mission...
@@ -71,30 +57,28 @@ Mission paused.
 Resuming mission...
 Resumed mission.
 Mission status update: 2 / 6
+...
 Mission status update: 2 / 6
-Mission status update: 2 / 6
 Mission status update: 3 / 6
-Mission status update: 3 / 6
-Mission status update: 3 / 6
+...
 Mission status update: 3 / 6
 Mission status update: 4 / 6
+...
 Mission status update: 4 / 6
-Mission status update: 4 / 6
-Mission status update: 4 / 6
 Mission status update: 5 / 6
+...
 Mission status update: 5 / 6
-Mission status update: 5 / 6
-Mission status update: 5 / 6
-[03:44:10|Debug] MAVLink: info: Mission finished, loitering. (device_impl.cpp:225)
+[01:05:40|Debug] MAVLink: info: Mission finished, loitering. (mavlink_system.cpp:286)
 Mission status update: 6 / 6
 Commanding RTL...
 Commanded RTL.
-[03:44:10|Debug] MAVLink: info: RTL: return at 498 m (10 m above home) (device_impl.cpp:225)
-[03:44:18|Debug] MAVLink: info: RTL: descend to 493 m (5 m above home) (device_impl.cpp:225)
-[03:44:22|Debug] MAVLink: info: RTL: loiter 5.0s (device_impl.cpp:225)
-[03:44:27|Debug] MAVLink: info: RTL: land at home (device_impl.cpp:225)
-[03:44:40|Debug] MAVLink: info: Landing detected (device_impl.cpp:225)
-[03:44:43|Debug] MAVLink: info: DISARMED by auto disarm on land (device_impl.cpp:225)
+[01:05:40|Debug] MAVLink: info: RTL: climb to 518 m (30 m above home) (mavlink_system.cpp:286)
+[01:05:48|Debug] MAVLink: info: RTL: return at 518 m (30 m above home) (mavlink_system.cpp:286)
+[01:05:55|Debug] MAVLink: info: RTL: descend to 493 m (5 m above home) (mavlink_system.cpp:286)
+[01:06:13|Debug] MAVLink: info: RTL: loiter 5.0s (mavlink_system.cpp:286)
+[01:06:18|Debug] MAVLink: critical: RTL: land at home (mavlink_system.cpp:286)
+[01:06:29|Debug] MAVLink: info: Landing detected (mavlink_system.cpp:286)
+[01:06:33|Debug] MAVLink: info: DISARMED by auto disarm on land (mavlink_system.cpp:286)
 Mission status update: 6 / 6
 Disarmed, exiting.
 ```
@@ -188,7 +172,18 @@ static std::shared_ptr<MissionItem> make_mission_item(double latitude_deg,
                                                       float gimbal_yaw_deg,
                                                       MissionItem::CameraAction camera_action);
 
-int main(int /*argc*/, char ** /*argv*/)
+void usage(std::string bin_name)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+
+int main(int argc, char **argv)
 {
     DroneCore dc;
 
@@ -202,8 +197,23 @@ int main(int /*argc*/, char ** /*argv*/)
             prom->set_value();
         });
 
-        ConnectionResult connection_result = dc.add_udp_connection();
-        handle_connection_err_exit(connection_result, "Connection failed: ");
+        std::string connection_url;
+        ConnectionResult connection_result;
+
+        if (argc == 2) {
+            connection_url = argv[1];
+            connection_result = dc.add_any_connection(connection_url);
+        } else {
+            usage(argv[0]);
+            return 1;
+        }
+
+        if (connection_result != ConnectionResult::SUCCESS) {
+            std::cout << ERROR_CONSOLE_TEXT << "Connection failed: "
+                      << connection_result_str(connection_result)
+                      << NORMAL_CONSOLE_TEXT << std::endl;
+            return 1;
+        }
 
         future_result.get();
     }

--- a/en/examples/fly_mission_qgc_plan.md
+++ b/en/examples/fly_mission_qgc_plan.md
@@ -20,75 +20,72 @@ The example terminal output should be similar to that shown below:
 > **Note** This is from a debug build of DroneCore. A release build will omit the "Debug" messages.
 
 ```
-$ ./fly_qgc_mission 
-Usage: ./fly_qgc_mission <path of QGC Mission plan>
-Importing mission from Default mission plan: ../../../plugins/mission/qgroundcontrol_sample.plan
+$ ./fly_qgc_mission udp://:14540
+```
+```
+Connection URL: udp://:14540
+Importing mission from mission plan: ../../../plugins/mission/qgroundcontrol_sample.plan
 Waiting to discover system...
-[02:25:09|Info ] New system on: 127.0.0.1:14557 (udp_connection.cpp:211)
-[02:25:09|Debug] MAVLink: info: DISARMED by auto disarm on land (system.cpp:247)
-[02:25:09|Debug] Discovered 4294967298 (dronecore_impl.cpp:219)
+[01:11:21|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:208)
+[01:11:21|Debug] New: System ID: 1 Comp ID: 1 (dronecore_impl.cpp:286)
+[01:11:21|Debug] Component Autopilot added. (mavlink_system.cpp:349)
+[01:11:21|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2018-05-23/0 (mavlink_system.cpp:286)
+[01:11:22|Debug] Found 1 component(s). (mavlink_system.cpp:481)
+[01:11:22|Debug] Discovered 4294967298 (mavlink_system.cpp:483)
 Discovered system with UUID: 4294967298
 Waiting for system to be ready
+...
 Waiting for system to be ready
 System ready
 Found 8 mission items in the given QGC plan.
 Uploading mission...
-[02:25:11|Debug] Send mission item 0 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 1 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 2 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 3 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 4 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 5 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 6 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 7 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 8 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 9 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 10 (mission_impl.cpp:781)
-[02:25:11|Debug] Send mission item 11 (mission_impl.cpp:781)
-[02:25:12|Debug] Send mission item 12 (mission_impl.cpp:781)
-[02:25:12|Debug] Send mission item 13 (mission_impl.cpp:781)
-[02:25:12|Debug] Send mission item 14 (mission_impl.cpp:781)
+[01:11:30|Debug] Send mission item 0 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 1 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 2 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 3 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 4 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 5 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 6 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 7 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 8 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 9 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 10 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 11 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 12 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 13 (mission_impl.cpp:904)
+[01:11:30|Debug] Send mission item 14 (mission_impl.cpp:904)
+[01:11:30|Info ] Mission accepted (mission_impl.cpp:162)
 Mission uploaded.
 Arming...
-[02:25:12|Info ] Mission accepted (mission_impl.cpp:146)
 Armed.
 Starting mission.
-[02:25:12|Debug] MAVLink: info: ARMED by arm/disarm component command (device.cpp:247)
-[02:25:12|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2018-02-15/0 (device.cpp:247)
+[01:11:30|Debug] MAVLink: info: ARMED by arm/disarm component command (mavlink_system.cpp:286)
 Started mission.
-[02:25:12|Debug] MAVLink: info: Executing mission. (device.cpp:247)
-[02:25:12|Debug] MAVLink: info: Takeoff to 15.0 meters above home. (device.cpp:247)
-[02:25:12|Debug] MAVLink: info: Takeoff detected (device.cpp:247)
+[01:11:30|Debug] MAVLink: info: Executing mission. (mavlink_system.cpp:286)
+[01:11:30|Debug] MAVLink: info: Takeoff to 15.0 meters above home. (mavlink_system.cpp:286)
+[01:11:30|Debug] MAVLink: info: Takeoff detected (mavlink_system.cpp:286)
 Mission status update: 0 / 8
 Mission status update: 1 / 8
 Mission status update: 1 / 8
-Mission status update: 1 / 8
-Mission status update: 1 / 8
 Mission status update: 2 / 8
-Mission status update: 2 / 8
-Mission status update: 2 / 8
+...
 Mission status update: 2 / 8
 Mission status update: 3 / 8
-Mission status update: 3 / 8
-Mission status update: 3 / 8
-Mission status update: 3 / 8
+...
 Mission status update: 4 / 8
-Mission status update: 4 / 8
-Mission status update: 4 / 8
+...
 Mission status update: 4 / 8
 Mission status update: 5 / 8
-Mission status update: 5 / 8
-Mission status update: 5 / 8
+...
 Mission status update: 5 / 8
 Mission status update: 6 / 8
-Mission status update: 6 / 8
-Mission status update: 6 / 8
+...
 Mission status update: 6 / 8
 Mission status update: 7 / 8
+...
 Mission status update: 7 / 8
-Mission status update: 7 / 8
-[02:26:19|Debug] MAVLink: info: Mission finished, loitering. (device.cpp:247)
 Mission status update: 8 / 8
+[01:12:41|Debug] MAVLink: info: Mission finished, loitering. (mavlink_system.cpp:286)
 Commanding RTL...
 Commanded RTL.
 ```
@@ -187,20 +184,43 @@ inline void handle_mission_err_exit(Mission::Result result, const std::string &m
 inline void handle_connection_err_exit(ConnectionResult result,
                                        const std::string &message);
 
+
+
+void usage(std::string bin_name)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name <<
+              " <connection_url> [path of QGC Mission plan]" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+
 int main(int argc, char **argv)
 {
+    DroneCore dc;
+    std::string connection_url;
+    ConnectionResult connection_result;
+
+
     // Locate path of QGC Sample plan
     std::string qgc_plan = "../../../plugins/mission/qgroundcontrol_sample.plan";
 
-    if (argc != 2) {
-        std::cout << "Usage: " << argv[0] << " <path of QGC Mission plan>\n";
-        std::cout << "Importing mission from Default mission plan: " << qgc_plan << std::endl;
-    } else if (argc == 2) {
-        std::cout << "Importing mission from mission plan: " << qgc_plan << std::endl;
-        qgc_plan = argv[1];
+    if (argc != 2 && argc != 3) {
+        usage(argv[0]);
+        return 1;
     }
 
-    DroneCore dc;
+    connection_url = argv[1];
+    if (argc == 3) {
+        qgc_plan = argv[2];
+    }
+
+    std::cout << "Connection URL: " << connection_url << std::endl;
+    std::cout << "Importing mission from mission plan: " << qgc_plan << std::endl;
+
 
     {
         auto prom = std::make_shared<std::promise<void>>();
@@ -212,7 +232,7 @@ int main(int argc, char **argv)
             prom->set_value();
         });
 
-        ConnectionResult connection_result = dc.add_udp_connection();
+        connection_result = dc.add_any_connection(connection_url);
         handle_connection_err_exit(connection_result, "Connection failed: ");
 
         future_result.get();

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -15,34 +15,49 @@ The example terminal output should be similar to that shown below:
 > **Note** This is from a debug build of DroneCore. A release build will omit the "Debug" messages.
 
 ```sh
-$ ./takeoff_and_land 
+$ ./takeoff_and_land udp://:14540
+```
+```sh
 Waiting to discover system...
-[03:34:57|Info ] New system on: 127.0.0.1:14557 (udp_connection.cpp:210)
-[03:34:57|Debug] Discovered 4294967298 (dronecore_impl.cpp:234)
+[03:15:08|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:208)
+[03:15:08|Debug] New: System ID: 1 Comp ID: 1 (dronecore_impl.cpp:286)
+[03:15:08|Debug] Component Autopilot added. (mavlink_system.cpp:330)
+[03:15:08|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2018-05-18/0 (mavlink_system.cpp:267)
+[03:15:09|Debug] Found 1 component(s). (mavlink_system.cpp:462)
+[03:15:09|Debug] Discovered 4294967298 (mavlink_system.cpp:464)
 Discovered system with UUID: 4294967298
-Arming...
-Taking off...
-[03:34:59|Debug] MAVLink: info: ARMED by arm/disarm component command (device_impl.cpp:225)
-[03:34:59|Debug] MAVLink: info: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:225)
-[03:34:59|Debug] MAVLink: info: Takeoff detected (device_impl.cpp:225)
-[03:34:59|Debug] MAVLink: critical: Using minimum takeoff altitude: 2.50 m (device_impl.cpp:225)
+[03:15:09|Debug] We got an ack: 520 (mavlink_commands.cpp:140)
+[03:15:10|Debug] We got an ack: 511 (mavlink_commands.cpp:140)
+[03:15:10|Debug] We got an ack: 511 (mavlink_commands.cpp:140)
+Vehicle is getting ready to arm
 Altitude: 0 m
-Altitude: 1.381 m
-Altitude: 2.283 m
-Altitude: 2.519 m
-Altitude: 2.55 m
-Altitude: 2.53 m
-Altitude: 2.508 m
-Altitude: 2.491 m
-Altitude: 2.479 m
-Altitude: 2.471 m
+Vehicle is getting ready to arm
+Altitude: -0.002 m
+Arming...
+[03:15:12|Debug] We got an ack: 176 (mavlink_commands.cpp:140)
+[03:15:12|Debug] We got an ack: 400 (mavlink_commands.cpp:140)
+Taking off...
+[03:15:12|Debug] MAVLink: info: ARMED by arm/disarm component command (mavlink_system.cpp:267)
+[03:15:12|Debug] We got an ack: 176 (mavlink_commands.cpp:140)
+[03:15:12|Debug] We got an ack: 22 (mavlink_commands.cpp:140)
+[03:15:12|Debug] MAVLink: info: Using minimum takeoff altitude: 2.50 m (mavlink_system.cpp:267)
+[03:15:12|Debug] MAVLink: info: Takeoff detected (mavlink_system.cpp:267)
+[03:15:12|Debug] MAVLink: critical: Using minimum takeoff altitude: 2.50 m (mavlink_system.cpp:267)
+Altitude: 0.95 m
+Altitude: 2.113 m
+Altitude: 2.457 m
+...
+Altitude: 2.494 m
+Altitude: 2.497 m
+Altitude: 2.498 m
 Landing...
-[03:35:09|Debug] MAVLink: info: Landing at current position (device_impl.cpp:225)
-Altitude: 2.321 m
-Altitude: 1.587 m
-Altitude: 0.813 m
-Altitude: 0.025 m
-Altitude: -0.483 m
+[03:15:22|Debug] We got an ack: 21 (mavlink_commands.cpp:140)
+[03:15:22|Debug] MAVLink: info: Landing at current position (mavlink_system.cpp:267)
+Altitude: 1.945 m
+Altitude: 1.192 m
+Altitude: 0.475 m
+Altitude: -0.222 m
+Altitude: -0.665 m
 Finished...
 ```
 

--- a/en/examples/takeoff_and_land.md
+++ b/en/examples/takeoff_and_land.md
@@ -19,45 +19,38 @@ $ ./takeoff_and_land udp://:14540
 ```
 ```sh
 Waiting to discover system...
-[03:15:08|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:208)
-[03:15:08|Debug] New: System ID: 1 Comp ID: 1 (dronecore_impl.cpp:286)
-[03:15:08|Debug] Component Autopilot added. (mavlink_system.cpp:330)
-[03:15:08|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2018-05-18/0 (mavlink_system.cpp:267)
-[03:15:09|Debug] Found 1 component(s). (mavlink_system.cpp:462)
-[03:15:09|Debug] Discovered 4294967298 (mavlink_system.cpp:464)
+[11:51:14|Info ] New device on: 127.0.0.1:14557 (udp_connection.cpp:208)
+[11:51:14|Debug] New: System ID: 1 Comp ID: 1 (dronecore_impl.cpp:286)
+[11:51:14|Debug] Component Autopilot added. (mavlink_system.cpp:349)
+[11:51:14|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2018-05-23/0 (mavlink_system.cpp:286)
+[11:51:15|Debug] Found 1 component(s). (mavlink_system.cpp:481)
+[11:51:15|Debug] Discovered 4294967298 (mavlink_system.cpp:483)
 Discovered system with UUID: 4294967298
-[03:15:09|Debug] We got an ack: 520 (mavlink_commands.cpp:140)
-[03:15:10|Debug] We got an ack: 511 (mavlink_commands.cpp:140)
-[03:15:10|Debug] We got an ack: 511 (mavlink_commands.cpp:140)
+Vehicle is getting ready to arm
+Vehicle is getting ready to arm
+Altitude: 0.007 m
 Vehicle is getting ready to arm
 Altitude: 0 m
-Vehicle is getting ready to arm
-Altitude: -0.002 m
 Arming...
-[03:15:12|Debug] We got an ack: 176 (mavlink_commands.cpp:140)
-[03:15:12|Debug] We got an ack: 400 (mavlink_commands.cpp:140)
 Taking off...
-[03:15:12|Debug] MAVLink: info: ARMED by arm/disarm component command (mavlink_system.cpp:267)
-[03:15:12|Debug] We got an ack: 176 (mavlink_commands.cpp:140)
-[03:15:12|Debug] We got an ack: 22 (mavlink_commands.cpp:140)
-[03:15:12|Debug] MAVLink: info: Using minimum takeoff altitude: 2.50 m (mavlink_system.cpp:267)
-[03:15:12|Debug] MAVLink: info: Takeoff detected (mavlink_system.cpp:267)
-[03:15:12|Debug] MAVLink: critical: Using minimum takeoff altitude: 2.50 m (mavlink_system.cpp:267)
-Altitude: 0.95 m
-Altitude: 2.113 m
-Altitude: 2.457 m
+[11:51:29|Debug] MAVLink: info: ARMED by arm/disarm component command (mavlink_system.cpp:286)
+[11:51:29|Debug] MAVLink: info: Using minimum takeoff altitude: 2.50 m (mavlink_system.cpp:286)
+[11:51:30|Debug] MAVLink: info: Takeoff detected (mavlink_system.cpp:286)
+[11:51:30|Debug] MAVLink: critical: Using minimum takeoff altitude: 2.50 m (mavlink_system.cpp:286)
+Altitude: 0.048 m
+Altitude: 1.6 m
+Altitude: 2.26 m
 ...
-Altitude: 2.494 m
-Altitude: 2.497 m
-Altitude: 2.498 m
+Altitude: 2.506 m
+Altitude: 2.486 m
+[11:51:39|Debug] MAVLink: info: data link #0 lost (mavlink_system.cpp:286)
+Altitude: 2.479 m
 Landing...
-[03:15:22|Debug] We got an ack: 21 (mavlink_commands.cpp:140)
-[03:15:22|Debug] MAVLink: info: Landing at current position (mavlink_system.cpp:267)
-Altitude: 1.945 m
-Altitude: 1.192 m
-Altitude: 0.475 m
-Altitude: -0.222 m
-Altitude: -0.665 m
+[11:51:39|Debug] MAVLink: info: Landing at current position (mavlink_system.cpp:286)
+Altitude: 2.277 m
+...
+Altitude: 0.099 m
+Altitude: -0.464 m
 Finished...
 ```
 
@@ -115,7 +108,16 @@ using namespace std::chrono;
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" //Turn text on console blue
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
-void usage(std::string arg);
+void usage(std::string bin_name)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
 
 int main(int argc, char **argv)
 {
@@ -124,12 +126,12 @@ int main(int argc, char **argv)
     ConnectionResult connection_result;
 
     bool discovered_system = false;
-    if (argc == 1) {
-        usage(argv[0]);
-        connection_result = dc.add_any_connection();
-    } else {
+    if (argc == 2) {
         connection_url = argv[1];
         connection_result = dc.add_any_connection(connection_url);
+    } else {
+        usage(argv[0]);
+        return 1;
     }
 
     if (connection_result != ConnectionResult::SUCCESS) {
@@ -218,15 +220,5 @@ int main(int argc, char **argv)
     sleep_for(seconds(5));
     std::cout << "Finished..." << std::endl;
     return 0;
-}
-
-void usage(std::string arg)
-{
-    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << arg << " [connection_url]" << std::endl
-              << "Connection URL format should be :" << std::endl
-              << " For TCP : tcp://[server_host][:server_port]" << std::endl
-              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl;
-    std::cout << "Default connection URL is udp://:14540" << std::endl;
 }
 ```

--- a/en/examples/transition_vtol_fixed_wing.md
+++ b/en/examples/transition_vtol_fixed_wing.md
@@ -7,26 +7,27 @@ This example shows how you can use DroneCore to transition between VTOL copter a
 
 ## Running the Example {#run_example}
 
-The example must be run against a VTOL aircraft. Otherwise the example is built and run [in the standard way](../examples/README.md#trying_the_examples).
+The example must be run against a VTOL aircraft (simulated or otherwise). Otherwise the example is built and run [in the standard way](../examples/README.md#trying_the_examples).
 
 > **Tip** Instructions for running the Gazebo simulator for a standard VTOL can be found here: [PX4 Development Guide > Gazebo Simulation](https://dev.px4.io/en/simulation/gazebo.html#standard-vtol). jMAVSim does not support VTOL simulation.
 
 The example terminal output for a debug build of DroneCore should be similar to that shown below (a release build will omit the "Debug" messages):
 
 ```
-$ ./transition_vtol_fixed_wing 
+$ ./transition_vtol_fixed_wing udp://:14540
+```
+```
 Waiting to discover system...
 [10:24:42|Info ] New system on: 127.0.0.1:14557 (udp_connection.cpp:210)
-[10:24:42|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2017-11-21/0 (device_impl.cpp:229)
-[10:24:42|Debug] MAVLink: info: Landing detected (device_impl.cpp:229)
-[10:24:43|Debug] Discovered 4294967298 (dronecore_impl.cpp:234)
+[10:24:42|Debug] MAVLink: info: [logger] file: rootfs/fs/microsd/log/2017-11-21/0 (mavlink_system.cpp:286)
+[10:24:43|Debug] Discovered 4294967298 (mavlink_system.cpp:483)
 Discovered system with UUID: 4294967298
 Arming...
 Taking off...
-[10:24:44|Debug] MAVLink: info: ARMED by arm/disarm component command (device_impl.cpp:229)
-[10:24:44|Debug] MAVLink: info: Using minimum takeoff altitude: 10.00 m (device_impl.cpp:229)
-[10:24:44|Debug] MAVLink: info: Takeoff detected (device_impl.cpp:229)
-[10:24:44|Debug] MAVLink: critical: Using minimum takeoff altitude: 10.00 m (device_impl.cpp:229)
+[10:24:44|Debug] MAVLink: info: ARMED by arm/disarm component command (mavlink_system.cpp:286)
+[10:24:44|Debug] MAVLink: info: Using minimum takeoff altitude: 10.00 m (mavlink_system.cpp:286)
+[10:24:44|Debug] MAVLink: info: Takeoff detected (mavlink_system.cpp:286)
+[10:24:44|Debug] MAVLink: critical: Using minimum takeoff altitude: 10.00 m (mavlink_system.cpp:286)
 Altitude: 0.079 m
 Altitude: 0.507 m
 ...
@@ -42,25 +43,26 @@ Altitude: 17.083 m
 ...
 Return to launch...
 Altitude: 11.884 m
-[10:25:09|Debug] MAVLink: info: RTL: climb to 518 m (29 m above home) (device_impl.cpp:229)
+[10:25:09|Debug] MAVLink: info: RTL: climb to 518 m (29 m above home) (mavlink_system.cpp:286)
 Altitude: 13.61 m
 ...
 Altitude: 27.489 m
 Altitude: 28.892 m
-[10:25:18|Debug] MAVLink: info: RTL: return at 517 m (29 m above home) (device_impl.cpp:229)
+[10:25:18|Debug] MAVLink: info: RTL: return at 517 m (29 m above home) (mavlink_system.cpp:286)
 Altitude: 29.326 m
 Altitude: 29.33 m
 ...
 Altitude: 29.323 m
 Altitude: 29.357 m
 Landing...
-[10:25:29|Debug] MAVLink: info: Landing at current position (device_impl.cpp:229)
+[10:25:29|Debug] MAVLink: info: Landing at current position (mavlink_system.cpp:286)
 Altitude: 29.199 m
 Altitude: 28.722 m
 Altitude: 28.189 m
 Altitude: 27.62 m
 Finished...
 ```
+
 
 ## How it works
 
@@ -100,6 +102,7 @@ target_link_libraries(transition_vtol_fixed_wing
 [transition_vtol_fixed_wing.cpp](https://github.com/dronecore/DroneCore/blob/{{ book.github_branch }}/example/transition_vtol_fixed_wing/transition_vtol_fixed_wing.cpp)
 
 ```cpp
+
 #include <chrono>
 #include <cstdint>
 #include <dronecore/action.h>
@@ -116,13 +119,33 @@ using namespace dronecore;
 #define TELEMETRY_CONSOLE_TEXT "\033[34m" //Turn text on console blue
 #define NORMAL_CONSOLE_TEXT "\033[0m"  //Restore normal console colour
 
-int main(int /*argc*/, char ** /*argv*/)
+
+void usage(std::string bin_name)
+{
+    std::cout << NORMAL_CONSOLE_TEXT << "Usage : " << bin_name << " <connection_url>" << std::endl
+              << "Connection URL format should be :" << std::endl
+              << " For TCP : tcp://[server_host][:server_port]" << std::endl
+              << " For UDP : udp://[bind_host][:bind_port]" << std::endl
+              << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
+              << "For example, to connect to the simulator use URL: udp://:14540" << std::endl;
+}
+
+
+int main(int argc, char **argv)
 {
     DroneCore dc;
+    std::string connection_url;
+    ConnectionResult connection_result;
 
     bool discovered_system = false;
 
-    ConnectionResult connection_result = dc.add_udp_connection();
+    if (argc == 2) {
+        connection_url = argv[1];
+        connection_result = dc.add_any_connection(connection_url);
+    } else {
+        usage(argv[0]);
+        return 1;
+    }
 
     if (connection_result != ConnectionResult::SUCCESS) {
         std::cout << ERROR_CONSOLE_TEXT << "Connection failed: "
@@ -138,7 +161,8 @@ int main(int /*argc*/, char ** /*argv*/)
     });
 
     // We usually receive heartbeats at 1Hz, therefore we should find a system after around 2 seconds.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    sleep_for(std::chrono::seconds(2));
+
 
     if (!discovered_system) {
         std::cout << ERROR_CONSOLE_TEXT << "No system found, exiting." << NORMAL_CONSOLE_TEXT << std::endl;
@@ -150,6 +174,7 @@ int main(int /*argc*/, char ** /*argv*/)
     // dc.system(uint64_t uuid);
     System &system = dc.system();
     auto telemetry = std::make_shared<Telemetry>(system);
+    auto action = std::make_shared<Action>(system);
 
     // We want to listen to the altitude of the drone at 1 Hz.
     const Telemetry::Result set_rate_result = telemetry->set_rate_position(1.0);
@@ -168,14 +193,11 @@ int main(int /*argc*/, char ** /*argv*/)
                   << std::endl;
     });
 
-
-    // Check if vehicle is ready to arm
-    if (telemetry->health_all_ok() != true) {
+    // Wait until vehicle is ready to arm.
+    while (telemetry->health_all_ok() != true) {
         std::cout << ERROR_CONSOLE_TEXT << "Vehicle not ready to arm" << NORMAL_CONSOLE_TEXT << std::endl;
-        return 1;
+        sleep_for(std::chrono::seconds(1));
     }
-
-    auto action = std::make_shared<Action>(system);
 
     // Arm vehicle
     std::cout << "Arming..." << std::endl;

--- a/en/guide/connections.md
+++ b/en/guide/connections.md
@@ -6,9 +6,9 @@ In order to detect vehicles you must first specify the communication ports that 
 
 ## Monitoring a Port
 
-Specify the port(s) to watch using one of the (synchronous) connection methods: [add_any_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a384ae5189b047dd3df8d7e90c42fa021), [add_udp_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a7a04fbacf95eb6b21418032c8287dfbb), [add_tcp_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a725640cb53c0d077e753ea2d22717b68) or [add_serial_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1abde7ed4d42875dc85c73d34fedab2902). All the methods are used similarly, and return immediately with a [ConnectionResult](../api_reference/namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) indicating whether they succeeded.
+Specify the port(s) to watch using one of the (synchronous) connection methods: [add_any_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a4d456788b98920c58b07e6a280642168), [add_udp_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a38e5715ec8817515ccaba5034da30bcd), [add_tcp_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1abaa49c13d6277177974a09ccffde82e1) or [add_serial_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1aa84b8bfba099631267a0319169c23c8e). All the methods are used similarly, and return immediately with a [ConnectionResult](../api_reference/namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc) indicating whether they succeeded.
 
-The [add_any_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a384ae5189b047dd3df8d7e90c42fa021) method can be used to set up monitoring for any of the supported port types (while the other methods set up specific connection types). The connection details are specified using the string formats shown below:
+The [add_any_connection()](../api_reference/classdronecore_1_1_drone_core.md#classdronecore_1_1_drone_core_1a4d456788b98920c58b07e6a280642168) method can be used to set up monitoring for any of the supported port types (while the other methods set up specific connection types). The connection details are specified using the string formats shown below:
 
 Connection | URL Format
 --- | ---
@@ -16,20 +16,19 @@ UDP | `udp://[Bind_host][:Bind_port]`
 TCP | `tcp://[Server_host][:Server_port]`
 Serial | `serial://[Dev_Node][:Baudrate]`
 
-The code snippet below shows how to set up monitoring with `add_any_connection()` using the default connection (`udp://127.0.0.1:14540`):
+The code snippet below shows how to set up monitoring with `add_any_connection()`:
 
 ```cpp
 DroneCore dc;
-ConnectionResult connection_result = dc.add_any_connection(); 
+std::string connection_url="udp://0.0.0.0:14540";
+ConnectionResult connection_result = dc.add_any_connection(connection_url);
 ASSERT_EQ(connection_result,ConnectionResult::SUCCESS)
 ```
 
-> **Note** The default connection is to the [standard PX4 broadcast UDP port](https://dev.px4.io/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540). This is the normal/most common way for offboard APIs to connect to PX4 over WiFi.
+> **Note** The connection string used above (`udp://0.0.0.0:14540`) is to the [standard PX4 broadcast UDP port](https://dev.px4.io/en/simulation/#default-px4-mavlink-udp-ports) for off-board APIs (14540). This is the normal/most common way for offboard APIs to connect to PX4 over WiFi.
 
-DroneCore also provides the [connection_result_str()](../api_reference/namespacedronecore.md#namespacedronecore_1a71899c532d8bedfa9654160fc175cce8) method, which you can use to create a human-readable string for the [ConnectionResult](../api_reference/namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc). The code fragment below shows how you might print this string to the console:
+DroneCore also provides the [connection_result_str()](../api_reference/namespacedronecore.md#namespacedronecore_1a71899c532d8bedfa9654160fc175cce8) method, which you can use to create a human-readable string for the [ConnectionResult](../api_reference/namespacedronecore.md#namespacedronecore_1a42d7afdc816d7f750e1a8d4282da0ddc). The code fragment below shows how you might print the string for the preceding code fragment to the console:
 ```cpp
-DroneCore dc;
-ConnectionResult connection_result = dc.add_udp_connection();
 std::cout << "Connection string: " << connection_result_str(connection_result) << std::endl;
 ```
 


### PR DESCRIPTION
Replaces #117

This updates reference following changes in: https://github.com/dronecore/DroneCore/pull/375 and Further changes needed as result of https://github.com/dronecore/DroneCore/pull/394

There are some outstanding questions:
* https://github.com/dronecore/DroneCore/pull/375#discussion_r185671513 - no default connection
* https://github.com/dronecore/DroneCore/pull/375/files#r185674108 - missing ref
* https://github.com/dronecore/DroneCore/issues/380

This changes some APIs so the changed references will need to be updated in example code etc. 

Also in trying the examples we say: 

> The simulator broadcasts to the standard PX4 UDP port for connecting to offboard APIs (14540). The examples connect to this port by default, using DroneCore::add_udp_connection()."

In fact only some of the examples use that method and they don't all have a default now.