### PR TITLE
Fix PX4 SITL command

### DIFF
--- a/en/contributing/test.md
+++ b/en/contributing/test.md
@@ -1,6 +1,6 @@
 # Testing
 
-The SDK has both unit and integration tests, written using the [Google C++ Test Framework](https://github.com/google/googletest/blob/master/googletest/docs/Primer.md) (`gtest`). 
+The SDK has both unit and integration tests, written using the [Google C++ Test Framework](https://github.com/google/googletest/blob/master/googletest/docs/Primer.md) (`gtest`).
 The unit tests are run every time new code is committed to the SDK codelines, and must pass before the code can be merged.
 
 This topic shows how to run the existing tests.
@@ -10,10 +10,10 @@ This topic shows how to run the existing tests.
 
 ## Running Unit Tests
 
-To run all unit tests: 
+To run all unit tests:
 
 ```
-make run_unit_tests 
+make run_unit_tests
 ```
 
 
@@ -21,7 +21,7 @@ make run_unit_tests
 
 Tests can be run against the simulator (either manually starting PX4 SITL or letting the tests start it automatically) or against a real vehicle.
 
-> **Tip** To run SITL you will need to install the *Gazebo* simulator. 
+> **Tip** To run SITL you will need to install the *Gazebo* simulator.
 This is included as part of the standard PX4 installation for [macOS](https://dev.px4.io/en/setup/dev_env_mac.html)
 and [Linux](https://dev.px4.io/en/setup/dev_env_linux.html#development-toolchain). It does not run on Windows.
 
@@ -58,7 +58,7 @@ make posix gazebo
 
 Then run the tests as shown:
 ```
-make run_integration_tests 
+make run_integration_tests
 ```
 
 ### Run With a Real Vehicle
@@ -68,7 +68,7 @@ make run_integration_tests
 Make sure you are connected to a vehicle and check the connection using e.g.:
 
 ```
-make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.TelemetryAsync"  
+make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.TelemetryAsync"
 ```
 
 

--- a/en/contributing/test.md
+++ b/en/contributing/test.md
@@ -31,7 +31,7 @@ Make sure that the [PX4 Gazebo simulation](https://dev.px4.io/en/simulation/gaze
 
 ```
 cd wherever/Firmware/
-make posix gazebo
+make px4_sitl gazebo
 ```
 
 Then press **Ctrl+C** to stop the simulation and run the integration tests:
@@ -53,7 +53,7 @@ Build and run the PX4 simulation manually:
 
 ```
 cd wherever/Firmware/
-make posix gazebo
+make px4_sitl gazebo
 ```
 
 Then run the tests as shown:

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -35,9 +35,9 @@ In order to set up the [jMAVSim](https://dev.px4.io/en/simulation/jmavsim.html) 
   Gazebo additionally supports a number of [other vehicles](https://dev.px4.io/en/simulation/gazebo.html#html#running-the-simulation) (e.g. VTOL, Rovers, fixed-wing etc.).
 
 After running a standard installation, a simulation can be started from the PX4 **/Firmware** directory using the command:
-* Multicopter (jMAVSim): `make posix_sitl_default jmavsim`
-* Multicopter (Gazebo): `make posix_sitl_default gazebo`
-* VTOL (Gazebo):  `make posix_sitl_default gazebo_standard_vtol`
+* Multicopter (jMAVSim): `make px4_sitl jmavsim`
+* Multicopter (Gazebo): `make px4_sitl gazebo`
+* VTOL (Gazebo):  `make px4_sitl gazebo_standard_vtol`
 
 
 ### Using QGroundControl

--- a/en/examples/README.md
+++ b/en/examples/README.md
@@ -15,23 +15,23 @@ Example | Description
 
 The examples are "largely" built and run in the same way, as described in the following section (any exceptions are covered in the page for the associated example).
 
-> **Warning** Some of the examples define flight behaviour relative to the default home position in the simulator (e.g. [Fly Mission](../examples/fly_mission.md)). 
+> **Warning** Some of the examples define flight behaviour relative to the default home position in the simulator (e.g. [Fly Mission](../examples/fly_mission.md)).
   Care should be taken if using them on a real vehicle.
 
 ## Trying the Examples {#trying_the_examples}
 
 The easiest way to test the examples is to use a [simulated PX4 vehicle](https://dev.px4.io/en/simulation/) that is running on the same computer.
-First start PX4 in SITL (Simulation), optionally start *QGroundControl* to observe the vehicle, then build and run the example code. 
+First start PX4 in SITL (Simulation), optionally start *QGroundControl* to observe the vehicle, then build and run the example code.
 
 > **Note** The simulator broadcasts to the standard PX4 UDP port for connecting to offboard APIs (14540). The examples connect to this port using either [add_any_connection()](../api_reference/classdronecode__sdk_1_1_dronecode_s_d_k.md#classdronecode__sdk_1_1_dronecode_s_d_k_1a51097e0dad30f0292a2ab4d3e9d91acf) or [add_udp_connection()](../api_reference/classdronecode__sdk_1_1_dronecode_s_d_k.md#classdronecode__sdk_1_1_dronecode_s_d_k_1ac242fb36bc018038fc1fc5ee4e5f21ad).
 
 
 ### Setting up a Simulator
 
-PX4 supports a [number of simulators](https://dev.px4.io/en/simulation/). 
+PX4 supports a [number of simulators](https://dev.px4.io/en/simulation/).
 In order to set up the [jMAVSim](https://dev.px4.io/en/simulation/jmavsim.html) or [Gazebo](https://dev.px4.io/en/simulation/gazebo.html) simulator, you can simply follow the standard PX4 toolchain setup instructions for [macOS](https://dev.px4.io/en/setup/dev_env_mac.html) or [Ubuntu Linux](https://dev.px4.io/en/setup/dev_env_linux.html#development-toolchain).
 
-> **Note** JMAVSim can only be used to simulate multicopters. 
+> **Note** JMAVSim can only be used to simulate multicopters.
   Gazebo additionally supports a number of [other vehicles](https://dev.px4.io/en/simulation/gazebo.html#html#running-the-simulation) (e.g. VTOL, Rovers, fixed-wing etc.).
 
 After running a standard installation, a simulation can be started from the PX4 **/Firmware** directory using the command:
@@ -42,7 +42,7 @@ After running a standard installation, a simulation can be started from the PX4 
 
 ### Using QGroundControl
 
-You can use *QGroundControl* to connect to PX4 and observe vehicle movement and behaviour while the examples are running. 
+You can use *QGroundControl* to connect to PX4 and observe vehicle movement and behaviour while the examples are running.
 *QGroundControl* will automatically connect to the PX4 simulation as soon as it is started.
 
 See [QGroundControl > Download and Install](https://docs.qgroundcontrol.com/en/getting_started/download_and_install.html) for information about setting up *QGroundControl* on your platform.
@@ -50,7 +50,7 @@ See [QGroundControl > Download and Install](https://docs.qgroundcontrol.com/en/g
 
 ### Building the Examples {#build_examples}
 
-To build the examples follow the instructions below, replacing *takeoff_and_land* with the name of the specific example. 
+To build the examples follow the instructions below, replacing *takeoff_and_land* with the name of the specific example.
 Any exceptions will be covered in the page for the associated example(s).
 
 #### Linux
@@ -73,7 +73,7 @@ make
 #### Windows
 
 First [Build and install the SDK C++ Library](../contributing/build.md#windows).
-Make sure that you [install the library and headers locally](../contributing/build.md#sdk_local_install) in the standard location: 
+Make sure that you [install the library and headers locally](../contributing/build.md#sdk_local_install) in the standard location:
 
 ```sh
 cmake --build . --target install
@@ -95,8 +95,8 @@ cmake --build .
 
 You can then run the example, specifying the connection URL as the first argument.
 When running with the Simulator, you will use the connection string: `udp://:14540`
- 
-On Linux/macOS you would run the following (from the **/build** directory): 
+
+On Linux/macOS you would run the following (from the **/build** directory):
 ```sh
 ./takeoff_and_land udp://:14540
 ```
@@ -107,10 +107,10 @@ For Windows you would run the following (from the **\build\Debug\** directory):
 ```
 
 
-> **Tip** Most examples will create a binary with the same name as the example. 
+> **Tip** Most examples will create a binary with the same name as the example.
 > The name that is used is specified in the **CMakeLists.txt** file as the first value in the call to `add_executable()`.
 
-If you have already started the simulation the example code should connect to PX4, 
+If you have already started the simulation the example code should connect to PX4,
 and you will be able to observe behaviour through the SDK terminal, SITL terminal, and/or *QGroundControl*.
 
 ## Troubleshooting
@@ -123,7 +123,7 @@ The following error is raised when you run an application/example on Linux and t
 error while loading shared libraries: libdronecode_sdk.so: cannot open shared object file: No such file or directory
 ```
 
-The solution is to update the linker cache so that the system can find the library. 
+The solution is to update the linker cache so that the system can find the library.
 On Ubuntu call the following:
 ```
 sudo ldconfig


### PR DESCRIPTION
With master and 1.9.x it is `px4_sitl` instead of `posix`.