### PR TITLE
Update C++ docs following build system changes

### DIFF
--- a/en/contributing/code_style.md
+++ b/en/contributing/code_style.md
@@ -2,43 +2,40 @@
 
 This topic contains the SDK C++ formatting and coding guidelines.
 
-> **Note** These guidelines are not written in stone! 
-  [Start a discussion](../README.md#getting-help) if you have suggestions for improvement (the project will consider anything other than "matters of personal taste"). 
+> **Note** These guidelines are not written in stone!   
+>   [Start a discussion](../README.md#getting-help) if you have suggestions for improvement \(the project will consider anything other than "matters of personal taste"\).
 
 ## Formatting and White Space
 
-All **.cpp** and **.h** files should be formatted according to the [astyle](http://astyle.sourceforge.net/) settings defined by [astylerc](https://github.com/Dronecode/DronecodeSDK/blob/{{ book.github_branch }}/astylerc).
+All **.cpp** and **.h** files should be formatted according to the `.clang-format` style.
 
 To automatically fix the formatting, run the command:
 
 ```
-make fix_style
+./tools/fix_style.sh .
 ```
-
-Explanations:
-
-- Line length should be kept below 100 characters.
-  - Enables 3-way-merges with 3 columns possible on decent monitors. 
-  - Discourages too many nested ifs. 
-  - Large enough o allow for verbose naming and prevent abbreviations.
-
 
 ## General Guidelines
 
 The following general guidelines should be used for all code:
 
-- C++11 is encouraged to allow developers to use C++11 features and the standard library. 
+* C++11 is encouraged to allow developers to use C++11 features and the standard library.   
   Examples:
-  - [`std::function`](http://en.cppreference.com/w/cpp/utility/functional/function) and [lambda expressions](http://en.cppreference.com/w/cpp/language/lambda)
-  - [`std::vector`](http://en.cppreference.com/w/cpp/container/vector), [`std::map`](http://www.cplusplus.com/reference/map/map/)
-  - [`std::thread`](http://www.cplusplus.com/reference/thread/thread/), [`std::mutex`](http://en.cppreference.com/w/cpp/thread/mutex)
 
-- `using namespace std` is discouraged ([read why](https://stackoverflow.com/questions/1452721/why-is-using-namespace-std-considered-bad-practice)). 
+  * [`std::function`](http://en.cppreference.com/w/cpp/utility/functional/function) and [lambda expressions](http://en.cppreference.com/w/cpp/language/lambda)
+  * [`std::vector`](http://en.cppreference.com/w/cpp/container/vector), [`std::map`](http://www.cplusplus.com/reference/map/map/)
+  * [`std::thread`](http://www.cplusplus.com/reference/thread/thread/), [`std::mutex`](http://en.cppreference.com/w/cpp/thread/mutex)
+
+* `using namespace std` is discouraged \([read why](https://stackoverflow.com/questions/1452721/why-is-using-namespace-std-considered-bad-practice)\).   
   If needed specific declarations can be used in the source files such as `using std::this_thread::sleep_for` to reduce verbosity.
-- The usage of namespacing wherever possible is encouraged (e.g. `enum class` is to be used over `enum`).
-- Filename extensions should be `.h` for header files and `.cpp` for source files (for consistency).
-- Variable and method names should err on the side of verbosity instead of being quick to type and read. Abbreviations are only to be used for small scopes and should not be exposed in public APIs.
-- All variables that have a physical unit should have the unit in the variable name (e.g. `_m` for meters, `_m_s` for meters/second).
-- Variable and method names should be `snake_case` and class/struct/enum names `CamelCase`. Private variables should start with an underscore, e.g.: `_variable_name`.
-- Try to exit functions early instead of nesting ifs ([read why](https://softwareengineering.stackexchange.com/questions/18454/should-i-return-from-a-function-early-or-use-an-if-statement)).
-- We don't use exceptions but use error codes. There are pros and cons for exceptions but given that the public API should be as simple as possible, it makes sense to refrain from exceptions altogether.
+
+* The usage of namespacing wherever possible is encouraged \(e.g. `enum class` is to be used over `enum`\).
+* Filename extensions should be `.h` for header files and `.cpp` for source files \(for consistency\).
+* Variable and method names should err on the side of verbosity instead of being quick to type and read. Abbreviations are only to be used for small scopes and should not be exposed in public APIs.
+* All variables that have a physical unit should have the unit in the variable name \(e.g. `_m` for meters, `_m_s` for meters/second\).
+* Variable and method names should be `snake_case` and class/struct/enum names `CamelCase`. Private variables should start with an underscore, e.g.: `_variable_name`.
+* Try to exit functions early instead of nesting ifs \([read why](https://softwareengineering.stackexchange.com/questions/18454/should-i-return-from-a-function-early-or-use-an-if-statement)\).
+* We don't use exceptions but use error codes. There are pros and cons for exceptions but given that the public API should be as simple as possible, it makes sense to refrain from exceptions altogether.
+
+
+

--- a/en/contributing/test.md
+++ b/en/contributing/test.md
@@ -5,46 +5,44 @@ The unit tests are run every time new code is committed to the SDK codelines, an
 
 This topic shows how to run the existing tests.
 
-> **Tip** For information on *writing* tests see: [Writing Plugins > Test Code](../contributing/plugins.md#testing).
-
+> **Tip** For information on _writing_ tests see: [Writing Plugins &gt; Test Code](../contributing/plugins.md#testing).
 
 ## Running Unit Tests
 
 To run all unit tests:
 
 ```
-make run_unit_tests
+./build/default/src/unit_tests_runner
 ```
-
 
 ## Running Integration Tests
 
 Tests can be run against the simulator (either manually starting PX4 SITL or letting the tests start it automatically) or against a real vehicle.
 
-> **Tip** To run SITL you will need to install the *Gazebo* simulator.
-This is included as part of the standard PX4 installation for [macOS](https://dev.px4.io/en/setup/dev_env_mac.html)
-and [Linux](https://dev.px4.io/en/setup/dev_env_linux.html#development-toolchain). It does not run on Windows.
+> **Tip** To run SITL you will need to install the _Gazebo_ simulator.
+> This is included as part of the standard PX4 installation for [macOS](https://dev.px4.io/en/setup/dev_env_mac.html)
+> and [Linux](https://dev.px4.io/en/setup/dev_env_linux.html#development-toolchain). It does not run on Windows.
 
 ### Autostart PX4 SITL
 
 Make sure that the [PX4 Gazebo simulation](https://dev.px4.io/en/simulation/gazebo.html) is built and works:
 
 ```
-cd wherever/Firmware/
+cd path/to/Firmware/
 make px4_sitl gazebo
 ```
 
 Then press **Ctrl+C** to stop the simulation and run the integration tests:
 
 ```
-cd wherever/DronecodeSDK/
-AUTOSTART_SITL=1 make run_integration_tests
+cd path/to/DronecodeSDK/
+AUTOSTART_SITL=1 ./build/debug/src/integration_tests/integration_tests_runner
 ```
 
-To run the tests without the 3D viewer (*gzclient*), use:
+To run the tests without the 3D viewer (_gzclient_), use:
 
 ```
-AUTOSTART_SITL=1 HEADLESS=1 make run_integration_tests
+AUTOSTART_SITL=1 HEADLESS=1 ./build/debug/src/integration_tests/integration_tests_runner
 ```
 
 ### Run PX4 SITL Manually
@@ -52,39 +50,36 @@ AUTOSTART_SITL=1 HEADLESS=1 make run_integration_tests
 Build and run the PX4 simulation manually:
 
 ```
-cd wherever/Firmware/
+cd path/to/Firmware/
 make px4_sitl gazebo
 ```
 
 Then run the tests as shown:
-```
-make run_integration_tests
-```
-
-### Run With a Real Vehicle
-
-> **Warning** Some of the tests might not be suited for real vehicles, especially the takeoff and kill test!
-
-Make sure you are connected to a vehicle and check the connection using e.g.:
 
 ```
-make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.TelemetryAsync"
+cd path/to/DronecodeSDK/
+./build/debug/src/integration_tests/integration_tests_runner
 ```
 
+> **Tip** The tests are designed to run in simulation, and may not be safe if run on a real vehicle.
 
-## Gtest Tricks
+### Gtest Tricks
 
 To list all integration tests:
+
 ```
-make && build/default/integration_tests/integration_tests_runner --gtest_list_tests
+./build/default/integration_tests/integration_tests_runner --gtest_list_tests
 ```
 
 To run a single integration test:
+
 ```
-make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.TelemetryAsync"
+./build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.TelemetryAsync"
 ```
 
 To run all telemetry tests:
+
 ```
-make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.Telemetry*"
+./build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.Telemetry*"
 ```
+


### PR DESCRIPTION
Update the C++ docs, now showing how to build using cmake.

@hamishwillee: I made the edits with gitbook-editor, and it somehow made some changes (like escaping parentheses `\(`). Should I revert that or is it fine to keep them?

@julianoes: I removed the build section about Docker, as I am not sure if it is up-to-date and I believe it is not so relevant (people who may want to do that would go check our scripts, and it is noise for people who don't know docker). I can revert it if you want.